### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ canary = "0.2.3"
 dashmap = "5.1.0"
 ahash = "0.7.6"
 camino = "1"
-compact_str = { version = "0.3.1", features = [ "serde" ] }
+compact_str = { version = "0.4", features = [ "serde" ] }
 derive_more = "0.99.17"
 derive-new = "0.5.9"
 async-trait = "0.1.52"

--- a/src/router.rs
+++ b/src/router.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ahash::RandomState;
 use camino::Utf8Path;
 use canary::{Channel, Result, err};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use dashmap::DashMap;
 use serde_repr::{Serialize_repr, Deserialize_repr};
 use async_recursion::async_recursion;
@@ -32,7 +32,7 @@ where
     }
 }
 
-type Key = CompactStr;
+type Key = CompactString;
 type InnerRoute = DashMap<Key, Storable, RandomState>;
 
 #[derive(Default, Clone)]


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning